### PR TITLE
Update vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -124,3 +124,7 @@ inoremap <F8> <Esc>:nohl<CR>a
 " switch between tabs
 nmap <F7> gt
 nmap <F6> gT
+
+
+" Stripping trailing whitespace
+autocmd FileType c,cpp,java,php autocmd BufWritePre <buffer> :%s/\s\+$//e


### PR DESCRIPTION
Strip whitespace from line ends on c, cpp, java, & php filetypes.
